### PR TITLE
Add ability to select host directory that is shared with Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Rather than wait around for this, WinApps was created as an easy, one command wa
 - Running a Windows RDP server in a background VM container
 - Checking the RDP server for installed applications such as Microsoft Office
 - If those programs are installed, it creates shortcuts leveraging FreeRDP for both the CLI and the GNOME tray
-- Files in your home directory are accessible via the `\\tsclient\home` mount inside the VM
+- Files in your home directory are accessible via the `\\tsclient\home` mount inside the VM (configurable)
 - You can right click on any files in your home directory to open with an application, too
 
 ## App support and "To Do"
@@ -32,9 +32,12 @@ You will need to create a `~/.config/winapps/winapps.conf` configuration file wi
 ``` bash
 RDP_USER="MyWindowsUser"
 RDP_PASS="MyWindowsPassword"
+#SHARE_PATH="$HOME"
 #RDP_IP="192.168.123.111"
 ```
 If you are using Option 2 below with a pre-existing non-KVM RDP server, you can use the `RDP_IP` to specify it's location. If you are running a VM in KVM with NAT enabled, leave `RDP_IP` commented out and WinApps will auto-detect the right local IP.
+
+Use `SHARE_PATH` to specify a path on the host to share with the VM. Defaults to your home directory if no value is set.
 
 ### Option 1 - Running KVM
 You can refer to the [KVM](https://www.linux-kvm.org) documentation for specifics, but the first thing you need to do is set up a Virtual Machine running Windows 10 Professional (or any version that supports RDP). First, clone WinApps and install KVM and FreeRDP:

--- a/bin/winapps
+++ b/bin/winapps
@@ -47,6 +47,13 @@ else
 	. "${HOME}/.winapps"
 fi
 
+if [ -z "${SHARE_PATH}" ]; then
+	SHARE_PATH="${HOME}"
+	SHARE_NAME='home'
+else
+	SHARE_NAME=$(basename "${SHARE_PATH}")
+fi
+
 if [ -z "${RDP_IP}" ]; then
 	if [ -z "$(groups |grep libvirt)" ]; then
 		echo "You are not a member of the libvirt group. Run the below then reboot."
@@ -64,13 +71,15 @@ if [ -z "${RDP_IP}" ]; then
 fi
 
 if [ "${1}" = "windows" ]; then
-	xfreerdp /u:"${RDP_USER}" /p:"${RDP_PASS}" /v:${RDP_IP} /dynamic-resolution +auto-reconnect +home-drive /wm-class:"Microsoft Windows" 1> /dev/null 2>&1 &
+	xfreerdp /u:"${RDP_USER}" /p:"${RDP_PASS}" /v:${RDP_IP} /dynamic-resolution +auto-reconnect /drive:"${SHARE_NAME}","${SHARE_PATH}" /wm-class:"Microsoft Windows" 1> /dev/null 2>&1 &
 elif [ "${1}" != "install" ]; then
 	. "${DIR}/../apps/${1}/info"
 	if [ -n "${2}" ]; then
-		FILE=$(echo "${2}" | sed 's|'"${HOME}"'|\\\\tsclient\\home|;s|/|\\|g;s|\\|\\\\|g')
-		xfreerdp /u:"${RDP_USER}" /p:"${RDP_PASS}" /v:${RDP_IP} +auto-reconnect +home-drive -wallpaper /span /wm-class:"${FULL_NAME}" /app:"${WIN_EXECUTABLE}" /app-icon:"${DIR}/../apps/${1}/icon.svg" /app-cmd:"\"${FILE}\"" 1> /dev/null 2>&1 &
+		HOST_WORKDIR=$(dirname "${2}")
+		GUEST_WORKDIR=$(echo "${HOST_WORKDIR}" | sed 's/\//_/g')
+		FILE="\\\\tsclient\\${GUEST_WORKDIR}\\$(basename "${2}")"
+		xfreerdp /u:"${RDP_USER}" /p:"${RDP_PASS}" /v:${RDP_IP} +auto-reconnect /drive:"${GUEST_WORKDIR}","${HOST_WORKDIR}" /drive:"${SHARE_NAME}","${SHARE_PATH}" -wallpaper /span /wm-class:"${FULL_NAME}" /app:"${WIN_EXECUTABLE}" /app-icon:"${DIR}/../apps/${1}/icon.svg" /app-cmd:"\"${FILE}\"" 1> /dev/null 2>&1 &
 	else
-		xfreerdp /u:"${RDP_USER}" /p:"${RDP_PASS}" /v:${RDP_IP} +auto-reconnect +home-drive -wallpaper /span /wm-class:"${FULL_NAME}" /app:"${WIN_EXECUTABLE}" /app-icon:"${DIR}/../apps/${1}/icon.svg" 1> /dev/null 2>&1 &
+		xfreerdp /u:"${RDP_USER}" /p:"${RDP_PASS}" /v:${RDP_IP} +auto-reconnect /drive:"${SHARE_NAME}","${SHARE_PATH}" -wallpaper /span /wm-class:"${FULL_NAME}" /app:"${WIN_EXECUTABLE}" /app-icon:"${DIR}/../apps/${1}/icon.svg" 1> /dev/null 2>&1 &
 	fi
 fi


### PR DESCRIPTION
I love this project, however I do not trust Windows not to mess with my home directory. This PR adds the ability for the user to select the directory that is shared with Windows.

Changes:

Add a `SHARE_PATH` option to the configuration file. The option allows the user to set the host directory that RDP will share with Windows. Defaults to `$HOME` if not set to preserve compatibility.

Previously, the script assumed that when a file is opened, it is already accessible via `\\tsclient\home`. Letting the user change the shared directory breaks this assumption. To fix this, the script will now automatically share the directory of the target file with Windows.

Example:
File on host: `/home/user/Documents/Work/work.docx`
File on Windows: `\\tsclient\_home_user_Documents_Work\work.docx`
