### PR TITLE
Add support for MS Project (2016, 2019 and o365

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,15 +55,15 @@ Note: The app list below is fueled by the community, and therefore many apps may
   </tr>
   <tr>
     <td><img src="apps/powerpoint/icon.svg" width="100"></td><td>Microsoft PowerPoint<br>(2016, 2019, o365)</td>
+    <td><img src="apps/project/icon.svg" width="100"></td><td>Microsoft Project<br>(2016, 2019, o365)</td>
+  </tr>
     <td><img src="apps/publisher/icon.svg" width="100"></td><td>Microsoft Publisher<br>(2016, 2019, o365)</td>
-  </tr>
-  <tr>
     <td><img src="apps/powershell/icon.svg" width="100"></td><td>Powershell</td>
-    <td><img src="apps/vs-enterprise-2019/icon.svg" width="100"></td><td>Visual Studio<br>(2019 - Ent|Pro|Com)</td>
+  <tr>
   </tr>
   <tr>
+    <td><img src="apps/vs-enterprise-2019/icon.svg" width="100"></td><td>Visual Studio<br>(2019 - Ent|Pro|Com)</td>
     <td><img src="icons/windows.svg" width="100"></td><td>Windows<br>(Full RDP session)</td>
-    <td>&nbsp;</td><td>&nbsp;</td>
   </tr>
 </table>
 

--- a/apps/project-o365-x86/info
+++ b/apps/project-o365-x86/info
@@ -1,0 +1,14 @@
+# GNOME shortcut name
+NAME="Project"
+
+# Used for descriptions and window class
+FULL_NAME="Microsoft Project"
+
+# The executable inside windows
+WIN_EXECUTABLE="C:\Program Files (x86)\Microsoft Office\root\Office16\WINPROJ.EXE"
+
+# GNOME categories
+CATEGORIES="Office"
+
+# GNOME mimetypes
+MIME_TYPES="application/msproj;application/msproject;application/x-msproject;application/x-ms-project;application/vnd.ms-project;"

--- a/apps/project-o365/info
+++ b/apps/project-o365/info
@@ -1,0 +1,14 @@
+# GNOME shortcut name
+NAME="Project"
+
+# Used for descriptions and window class
+FULL_NAME="Microsoft Project"
+
+# The executable inside windows
+WIN_EXECUTABLE="C:\Program Files\Microsoft Office\root\Office16\WINPROJ.EXE"
+
+# GNOME categories
+CATEGORIES="Office"
+
+# GNOME mimetypes
+MIME_TYPES="application/msproj;application/msproject;application/x-msproject;application/x-ms-project;application/vnd.ms-project;"

--- a/apps/project-x86/info
+++ b/apps/project-x86/info
@@ -1,0 +1,14 @@
+# GNOME shortcut name
+NAME="Project"
+
+# Used for descriptions and window class
+FULL_NAME="Microsoft Project"
+
+# The executable inside windows
+WIN_EXECUTABLE="C:\Program Files (x86)\Microsoft Office\Office16\WINPROJ.EXE"
+
+# GNOME categories
+CATEGORIES="Office"
+
+# GNOME mimetypes
+MIME_TYPES="application/msproj;application/msproject;application/x-msproject;application/x-ms-project;application/vnd.ms-project;"

--- a/apps/project/info
+++ b/apps/project/info
@@ -1,0 +1,14 @@
+# GNOME shortcut name
+NAME="Project"
+
+# Used for descriptions and window class
+FULL_NAME="Microsoft Project"
+
+# The executable inside windows
+WIN_EXECUTABLE="C:\Program Files\Microsoft Office\Office16\WINPROJ.EXE"
+
+# GNOME categories
+CATEGORIES="Office"
+
+# GNOME mimetypes
+MIME_TYPES="application/msproj;application/msproject;application/x-msproject;application/x-ms-project;application/vnd.ms-project;"


### PR DESCRIPTION
Wasn't able to get the proper icon for this PR.

MS Project icon wanted, dead or alive :drum:﻿
