### PR TITLE
Ensure BIN_PATH exists before installing

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -24,6 +24,7 @@ Please run "./installer.sh --system --uninstall" first.'
 
 function waInstall() {
 	${SUDO} mkdir -p "${SYS_PATH}/apps"
+	${SUDO} mkdir -p "${BIN_PATH}"
 	. "${DIR}/bin/winapps" install
 }
 


### PR DESCRIPTION
On certain systems (such as the XFCE spin of Fedora 33), `~/.local/bin` isn't present by default. This causes an issue where winapps would install shortcuts to the software it finds (eg Office) without being able to install said software, because it relies on `~/.local/bin` being in place, in case of an installation on the user level. This results in lots of broken application shortcuts despite everything else functioning as intended.

This commit fixes the issue by creating the BIN_PATH directory if necessary, before installing winapps as usual.