### PR TITLE
Document how to use a non-default keyboard layout (with AZERTY example)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,10 @@ RDP_PASS="MyWindowsPassword"
 #RDP_DOMAIN="MYDOMAIN"
 #RDP_IP="192.168.123.111"
 #RDP_SCALE=100
-#RDP_FLAGS=""
+# Uncomment the line below if using a French (AZERTY) keyboard layout:
+#RDP_FLAGS="/kbd:0x0000040C"
+# Run `xfreerdp /kbd-list` in a terminal to see a list of keyboard layout codes.
+
 #MULTIMON="true"
 #DEBUG="true"
 ```
@@ -177,8 +180,8 @@ The following optional commands can be used to manage your application configura
 
 ## Shout outs
 - Some icons pulled from
-  - Fluent UI React - Icons under [MIT License](https://github.com/Fmstrat/fluent-ui-react/blob/master/LICENSE.md) 
+  - Fluent UI React - Icons under [MIT License](https://github.com/Fmstrat/fluent-ui-react/blob/master/LICENSE.md)
   - Fluent UI - Icons under [MIT License](https://github.com/Fmstrat/fluentui/blob/master/LICENSE) with [restricted use](https://static2.sharepointonline.com/files/fabric/assets/microsoft_fabric_assets_license_agreement_nov_2019.pdf)
   - PKief's VSCode Material Icon Theme - Icons under [MIT License](https://github.com/Fmstrat/vscode-material-icon-theme/blob/master/LICENSE.md)
   - DiemenDesign's LibreICONS - Icons under [MIT License](https://github.com/Fmstrat/LibreICONS/blob/master/LICENSE)
-  
+


### PR DESCRIPTION
I can confirm running this solves the issue with the keyboard layout being stuck on QWERTY :slightly_smiling_face: 

Since AZERTY is one of the most common alternative keyboard layouts out there, I've listed it as an example.

This closes #99.