### PR TITLE
Replace hard-coded PC name 'RDPWindows' with the config variable 'RDP_NAME'

### DIFF
--- a/bin/winapps
+++ b/bin/winapps
@@ -54,12 +54,12 @@ if [ -z "${RDP_IP}" ]; then
 		echo '  sudo usermod -a -G kvm $(whoami)'
 		exit
 	fi
-	if [ -z "$(virsh list |grep RDPWindows)" ]; then
+	if [ -z "$(virsh list |grep ${RDP_NAME})" ]; then
 		echo "RDPWindows is not running, run:"
-		echo "  virsh start RDPWindows"
+		echo "  virsh start ${RDP_NAME}"
 		exit
 	fi
-	RDP_IP=$(virsh net-dhcp-leases default |grep RDPWindows |awk '{print $5}')
+	RDP_IP=$(virsh net-dhcp-leases default |grep "${RDP_NAME}" |awk '{print $5}')
 	RDP_IP=${RDP_IP%%\/*}
 fi
 

--- a/bin/winapps
+++ b/bin/winapps
@@ -47,6 +47,10 @@ if [ -z "$(which xfreerdp)" ]; then
 	exit
 fi
 
+if [ -z "${RDP_NAME}" ]; then
+	RDP_NAME="RDPWindows"
+fi
+
 if [ -z "${RDP_IP}" ]; then
 	if [ -z "$(groups |grep libvirt)" ]; then
 		echo "You are not a member of the libvirt group. Run the below then reboot."


### PR DESCRIPTION
This PR addresses issue #177 and provides an updated bin/winapps script that checks for an `RDP_NAME` variable in the configuration file; if not set, it will use the default name `RDPWindows`. This allows using of custom o pre-existing machine names.