### PR TITLE
File path may not exist, remove it

### DIFF
--- a/install/ExtractPrograms.ps1
+++ b/install/ExtractPrograms.ps1
@@ -210,6 +210,7 @@ Function Get-Icon {
 Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\*" |
     Select-Object -Property "(default)" -Unique |
     Where-Object {$_."(default)" -ne $null} |
+    Where-Object {Test-Path -Path $_."(default)".Trim('"') -PathType Leaf } |
     ForEach-Object {
         $Exe = $_."(default)".Trim('"')
         $Name = (Get-Item $Exe).VersionInfo.FileDescription.Trim() -replace "  "," "


### PR DESCRIPTION
In some cases, app file path may not exist, and the script will fail. Here check whether the file path exist.